### PR TITLE
allow requests without specific service

### DIFF
--- a/lib/ovh/rest.rb
+++ b/lib/ovh/rest.rb
@@ -41,7 +41,6 @@ module OVH
 
     [:get, :post, :put, :delete].each do |method|
       define_method method do |endpoint, payload = nil|
-        raise RESTError, "Invalid endpoint #{endpoint}, should match '/<service>/.*'" unless %r{^/\w+/.*$}.match(endpoint)
 
         url = @api_url + endpoint
         uri = URI.parse(url)

--- a/ovh-rest.gemspec
+++ b/ovh-rest.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = "ovh-rest"
-  spec.version       = "0.0.5"
+  spec.version       = "0.0.6"
   spec.authors       = ["Jonathan Amiez"]
   spec.email         = ["jonathan.amiez@fotolia.com"]
   spec.description   = "OVH REST API interface"


### PR DESCRIPTION
You were unable to set an endpoint without a service, so, you couldn't do things like list your services. Now you can.
